### PR TITLE
Correct URL to Talos website content

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Talos documentation is split into two parts:
 
 1. This repository, which is a [Hugo](https://gohugo.io) theme and associated tools to generate the static
    documentation site.
-2. The actual documentation content, which lives in the main [Talos repository](https://github.com/talos-systems/talos/tree/master/docs/content).
+2. The actual documentation content, which lives in the main [Talos repository](https://github.com/siderolabs/talos/tree/master/website).
 
 ## Local development
 


### PR DESCRIPTION
This PR corrects the URL in the README to point to where the website content for Talos lives.

It doesn't seem like this repository is still in active development, however I was searching for where the talos docs live to submit a PR, and I found this repository since [sideolabs/omni-docs](https://github.com/siderolabs/omni-docs) exists.
